### PR TITLE
Permanent redirect to HTTPS

### DIFF
--- a/ansible/files/traefik.toml
+++ b/ansible/files/traefik.toml
@@ -4,6 +4,7 @@ defaultEntryPoints = ["http", "https"]
   address = ":80"
     [entryPoints.http.redirect]
     entryPoint = "https"
+    permanent = true
   [entryPoints.https]
   address = ":443"
     [entryPoints.https.tls]


### PR DESCRIPTION
Before the migration to traefik we also had HSTS and other security headers.
I didn't manage to add them, but it would be great to have the back.
Here are some of them:
```
headers.SSLRedirect=true
headers.STSSeconds=315360000
headers.browserXSSFilter=true
headers.contentTypeNosniff=true
headers.forceSTSHeader=true
headers.frameDeny=true
```