### PR TITLE
explicit use ACME with HTTP

### DIFF
--- a/ansible/files/traefik.toml
+++ b/ansible/files/traefik.toml
@@ -18,3 +18,6 @@ onDemand = true
 
 [[acme.domains]]
    main = "traefik.piratenpartei.ch"
+
+[acme.httpChallenge]
+  entryPoint = "http"


### PR DESCRIPTION
The newest version of traefik must explicit activate the HTTP challenge for the ACME protocol.