### PR TITLE
change loglevel of traefik from DEBUG to ERROR

### DIFF
--- a/ansible/container-traefik.yaml
+++ b/ansible/container-traefik.yaml
@@ -10,7 +10,7 @@
     name: "traefik"
     ports: "80:80,443:443"
     state: started
-    command: --web --docker --docker.domain=piratenpartei.ch --logLevel=DEBUG
+    command: --web --docker --docker.domain=piratenpartei.ch
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /etc/traefik.toml:/traefik.toml

--- a/ansible/files/traefik.toml
+++ b/ansible/files/traefik.toml
@@ -1,4 +1,5 @@
 defaultEntryPoints = ["http", "https"]
+logLevel = "ERROR"
 [entryPoints]
   [entryPoints.http]
   address = ":80"


### PR DESCRIPTION
The log output of the running traefik is a huge waste of text and I want to switch the loglevel from DEBUG to ERROR.