### PR TITLE
Migrate to upstream redmine container

### DIFF
--- a/ansible/container-projects.yaml
+++ b/ansible/container-projects.yaml
@@ -40,7 +40,7 @@
            REDMINE_DB_DATABASE="projects"
            REDMINE_DB_MYSQL="mysql"
            REDMINE_DB_PASSWORD="{{ lookup('hashi_vault', 'secret=secret/projects/mysql/password:value') }}"
-           REDMINE_DB_USERNAME="redmine"
+           REDMINE_DB_USERNAME="projects"
            REDMINE_PLUGINS_MIGRATE=true
 
      - name: start backup container for first mysql container

--- a/ansible/container-projects.yaml
+++ b/ansible/container-projects.yaml
@@ -1,6 +1,6 @@
      - name: start mysql container
        docker_container:
-         image: "mysql:5"
+         image: "mariadb:10.4"
          name: "projects-mysql"
          state: started
          restart_policy: always
@@ -35,7 +35,7 @@
            - /data/files/projects/configuration.yml:/usr/src/redmine/config/configuration.yml:ro
            - /data/files/projects/files:/usr/src/redmine/files
            - /data/files/projects/plugins:/usr/src/redmine/plugins:ro
-           - /data/files/projects/themes:/usr/src/redmine/themes:ro
+           - /data/files/projects/themes/PurpleMine2:/usr/src/redmine/public/themes/PurpleMine2:ro
          env:
            REDMINE_DB_DATABASE="projects"
            REDMINE_DB_MYSQL="mysql"

--- a/ansible/container-projects.yaml
+++ b/ansible/container-projects.yaml
@@ -16,8 +16,8 @@
 
      - name: Redmine mail config
        become: true
-       template:
-         src: templates/redmine.yml
+       copy:
+         src: files/redmine.yml
          dest: /data/files/projects/configuration.yml
 
      - name: start projects/redmine container

--- a/ansible/container-projects.yaml
+++ b/ansible/container-projects.yaml
@@ -14,6 +14,12 @@
            MYSQL_USER="projects"
            MYSQL_DATABASE="projects"
 
+     - name: Redmine mail config
+       become: true
+       template:
+         src: templates/redmine.yml
+         dest: /data/files/projects/configuration.yml
+
      - name: start projects/redmine container
        docker_container:
          image: ppschweiz/redmine

--- a/ansible/container-projects.yaml
+++ b/ansible/container-projects.yaml
@@ -26,19 +26,16 @@
          links:
            - projects-mysql:mysql
          volumes:
-           - /data/files/projects/:/home/redmine/data/
+           - /data/files/projects/configuration.yml:/usr/src/redmine/config/configuration.yml:ro
+           - /data/files/projects/files:/usr/src/redmine/files
+           - /data/files/projects/plugins:/usr/src/redmine/plugins:ro
+           - /data/files/projects/themes:/usr/src/redmine/themes:ro
          env:
-           DB_HOST="mysql"
-           DB_USER="projects"
-           DB_PASS="{{ lookup('hashi_vault', 'secret=secret/projects/mysql/password:value') }}"
-           DB_NAME="projects"
-           DB_TYPE="mysql"
-           REDMINE_HTTPS="true"
-           REDMINE_ATTACHMENTS_DIR="/home/redmine/data/files"
-           NGINX_MAX_UPLOAD_SIZE="1024m"
-           SMTP_HOST="smtprelay.piratenpartei.ch"
-           SMTP_PORT="25"
-           SMTP_ENABLED="true"
+           REDMINE_DB_DATABASE="projects"
+           REDMINE_DB_MYSQL="mysql"
+           REDMINE_DB_PASSWORD="{{ lookup('hashi_vault', 'secret=secret/projects/mysql/password:value') }}"
+           REDMINE_DB_USERNAME="redmine"
+           REDMINE_PLUGINS_MIGRATE=true
 
      - name: start backup container for first mysql container
        docker_container:

--- a/ansible/files/redmine.yml
+++ b/ansible/files/redmine.yml
@@ -1,0 +1,5 @@
+production:
+  delivery_method: :smtp
+  smtp_settings:
+    address: smtprelay.piratenpartei.ch
+    port: 25

--- a/ansible/templates/redmine.yml
+++ b/ansible/templates/redmine.yml
@@ -1,9 +1,0 @@
-production:
-  delivery_method: :smtp
-  smtp_settings:
-    address: smtprelay.piratenpartei.ch
-    port: 587
-    domain: piratenpartei.ch
-    authentication: :login
-    user_name: info@piratenpartei.ch
-    password: {{ lookup('hashi_vault', 'secret=secret/projects/smtprelay/password:value') }}

--- a/ansible/templates/redmine.yml
+++ b/ansible/templates/redmine.yml
@@ -1,0 +1,9 @@
+production:
+  delivery_method: :smtp
+  smtp_settings:
+    address: smtprelay.piratenpartei.ch
+    port: 587
+    domain: piratenpartei.ch
+    authentication: :login
+    user_name: info@piratenpartei.ch
+    password: {{ lookup('hashi_vault', 'secret=secret/projects/smtprelay/password:value') }}


### PR DESCRIPTION
Depends on https://github.com/ppschweiz/docker-redmine/pull/3

configuration.yml should contain something like this:
```yml
production:
  delivery_method: :smtp
  smtp_settings:
    address: smtprelay.piratenpartei.ch
    port: 587
    domain: piratenpartei.ch
    authentication: :login
    user_name: user@piratenpartei.ch
    password: redacted
```