### PR TITLE
Modernize Duplicity

### DIFF
--- a/ansible/container-backup.yaml
+++ b/ansible/container-backup.yaml
@@ -1,6 +1,6 @@
      - name: start duplicity container
        docker_container:
-         image: "datacoda/cron-duplicity"
+         image: "tecnativa/duplicity"
          name: "duplicity"
          state: started
          pull: True
@@ -11,6 +11,8 @@
            AWS_ACCESS_KEY_ID="{{ lookup('hashi_vault', 'secret=secret/duplicity/aws-access-key-id:value') }}"
            AWS_SECRET_ACCESS_KEY="{{ lookup('hashi_vault', 'secret=secret/duplicity/aws-secret-access-key:value') }}"
            PASSPHRASE="{{ lookup('hashi_vault', 'secret=secret/duplicity/passphrase:value') }}"
-           SOURCE_PATH="/data"
-           REMOTE_URL="s3://sos-ch-dk-2.exo.io/pps-backup"
-           PARAMS="--exclude /data/mysql --exclude /data/migration --exclude /data/migration-mysql"
+           SRC="/data"
+           DST="s3://sos-ch-dk-2.exo.io/pps-backup"
+           OPTIONS="--allow-source-mismatch --exclude /data/mysql --exclude /data/migration --exclude /data/migration-mysql"
+           JOB_1_WHAT=backup
+           JOB_1_WHEN=hourly


### PR DESCRIPTION
`datacoda/cron-duplicity` is not maintained, let's use [tecnativa/duplicity](https://github.com/Tecnativa/docker-duplicity).
Additional options like `--s3-european-buckets --s3-use-new-style` and SMTP can also be evaluated.