### PR TITLE
Stick on latest Traefik maroilles

### DIFF
--- a/ansible/container-traefik.yaml
+++ b/ansible/container-traefik.yaml
@@ -5,8 +5,9 @@
     dest: /etc/traefik.toml
 - name: Traefik
   docker_container:
-    image: "traefik"
+    image: "traefik:maroilles"
     restart_policy: always
+    pull: True
     name: "traefik"
     ports: "80:80,443:443"
     state: started


### PR DESCRIPTION
The upcomming `faisselle` (`2.x`) needs to be checked for breaking changes.