### PR TITLE
📦 NEW: listmonk

### DIFF
--- a/ansible/container-listmonk.yml
+++ b/ansible/container-listmonk.yml
@@ -1,0 +1,73 @@
+---
+- name: Create Listmonk network
+  become: true
+  docker_network:
+    name: net-listmonk
+    attachable: true
+    internal: true
+
+- name: Listmonk config
+  become: true
+  template:
+    src: templates/listmonk.toml.j2
+    dest: /var/srv/files/listmonk/config.toml
+    mode: '0644'
+
+- name: Listmonk auth
+  become: true
+  copy:
+    src: files/listmonk.pwd
+    dest: /var/srv/traefik/config/listmonk.pwd
+    mode: '0644'
+
+- name: start listmonk postgresql container
+  become: true
+  docker_container:
+    image: "postgres:13-alpine"
+    name: "listmonk-postgres"
+    state: started
+    restart_policy: always
+    pull: true
+    networks_cli_compatible: true
+    networks:
+      - name: net-listmonk
+    ulimits: nofile:4096:32768
+    volumes:
+      - /var/srv/postgresql/listmonk:/var/lib/posgresql/data:Z
+    env:
+      POSTGRES_PASSWORD="{{ lookup('hashi_vault', 'secret=secret/listmonk/postgresql/password:value') }}"
+      POSTGRES_USER="listmonk"
+      POSTGRES_DB="listmonk"
+
+- name: start listmonk container
+  become: true
+  docker_container:
+    image: "listmonk/listmonk:latest"
+    name: "listmonk"
+    labels:
+      "traefik.enable": "true"
+      "traefik.entryPoint": "https"
+      "traefik.http.routers.listmonk-public.rule": "Host(`newsletter.piratenpartei.ch`) && PathPrefix(`/subscription/`, `/link/`, `/campaign/`, `/public/`, `/webhooks/service/`)"
+      "traefik.http.routers.listmonk-public.tls.certresolver": "le"
+      "traefik.http.routers.listmonk-public.tls": "true"
+      "traefik.http.routers.listmonk-public.middlewares": "security-headers"
+      "traefik.http.routers.listmonk.rule": "Host(`newsletter.piratenpartei.ch`)"
+      "traefik.http.routers.listmonk.tls.certresolver": "le"
+      "traefik.http.routers.listmonk.tls": "true"
+      "traefik.http.routers.listmonk.middlewares": "listmonk"
+      "traefik.http.middlewares.listmonk.chain.middlewares": "security-headers@file,listmonk_auth"
+      "traefik.http.middlewares.listmonk_auth.digestauth.usersfile": "/config/listmonk.pwd"
+    state: started
+    #   SELECT THE STARTUP COMMAND (INSTALL or UPGRADE).
+    #     - INSTALL will WIPE all data !
+    #     - UPDATE is idempotent.
+    # command: [sh, -c, "yes | ./listmonk --install --config /listmonk/config.toml && ./listmonk --config /listmonk/config.toml"]
+    command: [sh, -c, "yes | ./listmonk --upgrade --config /listmonk/config.toml && ./listmonk --config /listmonk/config.toml"]
+    pull: true
+    networks_cli_compatible: true
+    networks:
+      - name: net-proxy
+      - name: net-listmonk
+    restart_policy: always
+    volumes:
+      - /var/srv/files/listmonk/config.toml:/listmonk/config.toml:z

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -17,5 +17,6 @@
     - import_tasks: container-backup.yml
     - import_tasks: container-projects.yml
     - import_tasks: container-otrs.yml
+    - import_tasks: container-listmonk.yml
       tags: otrs
     - import_tasks: container-nextcloud.yml

--- a/ansible/templates/listmonk.toml.j2
+++ b/ansible/templates/listmonk.toml.j2
@@ -1,0 +1,32 @@
+[app]
+# Interface and port where the app will run its webserver.  The default value
+# of localhost will only listen to connections from the current machine. To
+# listen on all interfaces use '0.0.0.0'. To listen on the default web address
+# port, use port 80 (this will require running with elevated permissions).
+address = "0.0.0.0:80"
+
+# BasicAuth authentication for the admin dashboard. This will eventually
+# be replaced with a better multi-user, role-based authentication system.
+# IMPORTANT: Leave both values empty to disable authentication on admin
+# only where an external authentication is already setup.
+admin_username = ""
+admin_password = ""
+
+# Database
+[db]
+host = "listmonk-postgres"
+port = 5432
+user = "listmonk"
+password = "{{ lookup('hashi_vault', 'secret=secret/listmonk/postgresql/password:value') }}"
+
+# Ensure that this database has been created in Postgres.
+database = "listmonk"
+
+ssl_mode = "disable"
+max_open = 25
+max_idle = 25
+max_lifetime = "300s"
+
+# Optional space separated Postgres DSN params. eg: "application_name=listmonk gssencmode=disable"
+params = ""
+


### PR DESCRIPTION
poc for listmonk as newsletter tool
authentication needs to be added to `ansible/files/listmonk.pwd` in the form of a digest auth (can be generated using `htdigest` using the realm `treafik`)